### PR TITLE
fix: handle missing DBus session on headless servers

### DIFF
--- a/proton/vpn/cli/__init__.py
+++ b/proton/vpn/cli/__init__.py
@@ -51,22 +51,27 @@ GTK_APP_ID = "proton.vpn.app.gtk"
 
 
 async def _vpn_gui_running() -> bool:
-    bus = await MessageBus(bus_type=BusType.SESSION).connect()
+    try:
+        bus = await MessageBus(bus_type=BusType.SESSION).connect()
 
-    reply = await bus.call(
-        Message(
-            destination="org.freedesktop.DBus",
-            path="/org/freedesktop/DBus",
-            interface="org.freedesktop.DBus",
-            member="ListNames",
+        reply = await bus.call(
+            Message(
+                destination="org.freedesktop.DBus",
+                path="/org/freedesktop/DBus",
+                interface="org.freedesktop.DBus",
+                member="ListNames",
+            )
         )
-    )
 
-    if reply.message_type == MessageType.ERROR:
+        if reply.message_type == MessageType.ERROR:
+            return False
+
+        session_bus_names = reply.body[0]
+        return GTK_APP_ID in session_bus_names
+    except Exception:
+        # No DBus session available (e.g. headless server).
+        # If DBus is not running, the GUI can't be running either.
         return False
-
-    session_bus_names = reply.body[0]
-    return GTK_APP_ID in session_bus_names
 
 
 _CLICK_CONTEXT_SETTINGS = {"help_option_names": ['--help', '-h']}


### PR DESCRIPTION
## Summary

- Wraps `_vpn_gui_running()` DBus call in a try/except to gracefully handle headless environments where no DBus session bus is available
- When DBus is unavailable, the function returns `False` (no GUI can be running without DBus), allowing the CLI to proceed normally

## Problem

On headless Linux servers (no display, no DBus session), the CLI crashes at startup because `MessageBus(bus_type=BusType.SESSION).connect()` throws an unhandled exception. This prevents any CLI usage on servers — even basic commands like `signin` or `connect`.

Related: #2

## Test plan

- [ ] Verify CLI works on headless server without DBus session bus
- [ ] Verify CLI still detects running GUI app on desktop environments
- [ ] Verify `--help` still works in both environments