### PR TITLE
fixed removed api arguments

### DIFF
--- a/proton/vpn/cli/commands/location_discovery.py
+++ b/proton/vpn/cli/commands/location_discovery.py
@@ -178,7 +178,7 @@ async def list_cities_in_country(ctx, country: str):
     requested_country = requested_country.pop()
     table_data = []
 
-    for city in requested_country.locations:
+    for city in requested_country.cities:
         only_displayable_features = [
             feature_display_name
             for feature, feature_display_name in FEATURES_TO_DISPLAY.items()

--- a/proton/vpn/cli/core/controller.py
+++ b/proton/vpn/cli/core/controller.py
@@ -154,7 +154,6 @@ class Controller:  # pylint: disable=too-many-public-methods
         ProtonLogging.config(
             filename=LOGGING_FILENAME,
             logdirpath=LOGGING_DIR_PATH,
-            log_to_console=params.verbose
         )
 
         client_type_metadata = ClientTypeMetadata(
@@ -446,7 +445,7 @@ class Controller:  # pylint: disable=too-many-public-methods
             raise AuthenticationRequiredError
 
         server_list = await self.get_updated_server_list()
-        return server_list.group_by_country(group_by_city=True)
+        return server_list.group_by_country(cities=True)
 
     async def connect(
         self,

--- a/tests/unit/commands/test_location_discovery.py
+++ b/tests/unit/commands/test_location_discovery.py
@@ -241,7 +241,6 @@ def test_cities_listing_shows_all_available_features_for_city(
                         "Enabled": "1"
                     })
                 ],
-                group_by_city=True
             )
         ]
 
@@ -260,7 +259,7 @@ def test_cities_listing_shows_all_available_features_for_city(
     assert result.exit_code == 0
 
     only_country = get_all_countries()[0]
-    only_city = only_country.locations[0]
+    only_city = only_country.cities[0]
     for feature in only_city.features:
         if feature in FEATURES_TO_DISPLAY:
             assert FEATURES_TO_DISPLAY[feature] in result.output
@@ -297,7 +296,6 @@ def test_cities_listing_shows_all_available_cities(
                         "Enabled": "1"
                     })
                 ],
-                group_by_city=True
             )
         ]
 
@@ -316,9 +314,9 @@ def test_cities_listing_shows_all_available_cities(
     assert result.exit_code == 0
 
     only_country = get_all_countries()[0]
-    for city in only_country.locations:
+    for city in only_country.cities:
         assert city.name in result.output
 
     result_without_header = result.output.split("-\n", 1)[1]
     number_of_city_rows = result_without_header.count("\n") - 1
-    assert number_of_city_rows == len(only_country.locations)
+    assert number_of_city_rows == len(only_country.cities)


### PR DESCRIPTION
This PR fixes compatibility issues with the latest version of `python3-proton-vpn-api-core`.

In the `Country` class, access to the `locations` property has been renamed to `cities` to align with the updated API.
Hi,


Without this change, the code raises an `AttributeError` (the 'Country' object has no attribute 'locations') when attempting to list the cities for a given country.


Additionally, the `log_to_console` argument has been removed from calls to `ProtonLogging.config()`, as it is no longer supported in the updated API and was causing a `TypeError`, which broke tests that instantiate the Controller.


These changes are minimal and aim solely to restore compatibility with the current API, without altering existing behavior beyond what is strictly necessary.


Nilson Silva