### PR TITLE
Fix unhandled TimeoutError in connect()

### DIFF
--- a/proton/vpn/cli/core/controller.py
+++ b/proton/vpn/cli/core/controller.py
@@ -479,7 +479,10 @@ class Controller:  # pylint: disable=too-many-public-methods
             raise
         except (TimeoutError, VPNConnectionError):
             # If the connection fails, clean up NM setup
-            await self.disconnect()
+            try:
+                await self.disconnect()
+            except TimeoutError:
+                pass  # kill switch cleanup timed out, nothing more we can do
 
         connection_state = None
         if isinstance(connector.current_state, states.Connected):


### PR DESCRIPTION
Fix unhandled TimeoutError in connect() when kill switch cleanup times out

When connect() calls disconnect() as cleanup after a failed connection attempt, the TimeoutError raised by the kill switch NetworkManager cleanup was not caught, causing an unhandled exception crash instead of a graceful failure.

This fix wraps the disconnect() call in a try/except block to catch TimeoutError, allowing the program to fail gracefully.