### PR TITLE
fix: prevent SIGABRT crash in `protonvpn status` from Rust local agent background threads

### DIFF
--- a/proton/vpn/cli/__init__.py
+++ b/proton/vpn/cli/__init__.py
@@ -19,7 +19,10 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with ProtonVPN.  If not, see <https://www.gnu.org/licenses/>.
 """
+import atexit
 from importlib.metadata import version, PackageNotFoundError
+import os
+import signal
 import sys
 from typing import List, Optional
 
@@ -45,6 +48,26 @@ try:
     __version__ = version("proton-vpn-cli")
 except PackageNotFoundError:
     __version__ = "development"
+
+
+# Installed during interpreter shutdown to prevent core dumps from
+# Rust local_agent.abi3.so background threads that may call Python
+# callbacks during Py_FinalizeEx. Logs to stderr instead of dumping
+# core so the occurrence is still visible, but exits cleanly.
+def _handle_shutdown_abort(_signum, _frame):
+    sys.stderr.write(
+        "Warning: suppressed a SIGABRT during interpreter shutdown "
+        "(likely from local_agent.abi3.so background threads).\n"
+    )
+    os._exit(1)
+
+
+def _install_abort_guard():
+    signal.signal(signal.SIGABRT, _handle_shutdown_abort)
+
+
+atexit.register(_install_abort_guard)
+
 
 PROTON_VPN_LOGO = r"""
   ____            _               __     ______  _   _

--- a/proton/vpn/cli/commands/server.py
+++ b/proton/vpn/cli/commands/server.py
@@ -18,11 +18,13 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with ProtonVPN.  If not, see <https://www.gnu.org/licenses/>.
 """
+import asyncio
 from asyncio import CancelledError
 from typing import Optional
 
 import click
 
+from proton.vpn import logging as ProtonLogging
 from proton.vpn.cli._cli_constants import PROGRAM_NAME
 from proton.vpn.cli.core.exceptions import \
     AuthenticationRequiredError, \
@@ -38,6 +40,8 @@ from proton.vpn.session.servers.types import LogicalServer, ServerFeatureEnum
 from proton.vpn.cli.commands.account import SIGNIN_COMMAND
 from proton.vpn.cli.commands.command_utils import \
     inform_that_expired_serverlist_will_be_updated_if_necessary
+
+logger = ProtonLogging.getLogger(__name__)
 
 CONNECT_COMMAND = "connect"
 DISCONNECT_COMMAND = "disconnect"
@@ -266,6 +270,21 @@ async def status(ctx):
         ])
 
     click.echo("\n".join(status_lines))
+
+    # Prevent SIGABRT crash during Python interpreter shutdown.
+    # The Rust local_agent.abi3.so spawns tokio background threads that
+    # hold Python callbacks (on_status, on_error, getLogger). When the
+    # CLI exits and Py_FinalizeEx runs, these threads may try to acquire
+    # the GIL to call Python callbacks, triggering a SIGABRT. Stopping
+    # the agent listener here ensures tokio tasks are dropped before
+    # the asyncio loop closes.
+    if connection is not None and hasattr(connection, '_agent_listener'):
+        try:
+            agent_listener = connection._agent_listener
+            if agent_listener.is_running:
+                await asyncio.wait_for(agent_listener.stop(), timeout=5.0)
+        except Exception:  # pylint: disable=broad-except
+            logger.debug("Failed to stop local agent listener.", exc_info=True)
 
 
 @click.command(

--- a/tests/unit/commands/test_server.py
+++ b/tests/unit/commands/test_server.py
@@ -517,6 +517,74 @@ def test_status_shows_connected_with_server_details(
     assert "Protocol: wireguard" in result.output
 
 
+def _build_connected_mocks(controller_mock: AsyncMock) -> Mock:
+    connection_mock = Mock()
+    connection_mock.server_name = "CH#1"
+    connection_mock.protocol = "wireguard"
+    vpn_connector_mock = Mock()
+    vpn_connector_mock.current_state.context.connection = connection_mock
+    controller_mock.get_vpn_connector.return_value = vpn_connector_mock
+
+    server_mock = Mock()
+    server_mock.load = 42
+    server_mock.entry_country_name = "Switzerland"
+    server_mock.city = "Zurich"
+    server_mock.features = []
+    server_list_mock = Mock()
+    server_list_mock.get_by_name.return_value = server_mock
+    controller_mock.get_updated_server_list.return_value = server_list_mock
+
+    return connection_mock
+
+
+def test_status_stops_local_agent_listener_when_running(
+    controller_mock: AsyncMock,
+    cli_invoke
+):
+    connection_mock = _build_connected_mocks(controller_mock)
+    agent_listener_mock = Mock()
+    type(agent_listener_mock).is_running = PropertyMock(return_value=True)
+    agent_listener_mock.stop = AsyncMock()
+    connection_mock._agent_listener = agent_listener_mock
+
+    result = cli_invoke([STATUS_COMMAND])
+
+    assert result.exit_code == 0
+    agent_listener_mock.stop.assert_awaited_once()
+
+
+def test_status_does_not_stop_local_agent_listener_when_not_running(
+    controller_mock: AsyncMock,
+    cli_invoke
+):
+    connection_mock = _build_connected_mocks(controller_mock)
+    agent_listener_mock = Mock()
+    type(agent_listener_mock).is_running = PropertyMock(return_value=False)
+    agent_listener_mock.stop = AsyncMock()
+    connection_mock._agent_listener = agent_listener_mock
+
+    result = cli_invoke([STATUS_COMMAND])
+
+    assert result.exit_code == 0
+    agent_listener_mock.stop.assert_not_awaited()
+
+
+def test_status_succeeds_even_if_stopping_local_agent_listener_fails(
+    controller_mock: AsyncMock,
+    cli_invoke
+):
+    connection_mock = _build_connected_mocks(controller_mock)
+    agent_listener_mock = Mock()
+    type(agent_listener_mock).is_running = PropertyMock(return_value=True)
+    agent_listener_mock.stop = AsyncMock(side_effect=RuntimeError("boom"))
+    connection_mock._agent_listener = agent_listener_mock
+
+    result = cli_invoke([STATUS_COMMAND])
+
+    assert result.exit_code == 0
+    assert "Status: Connected" in result.output
+
+
 @pytest.mark.parametrize("server_list_expired", [True, False])
 def test_status_notifies_of_serverlist_update_when_expired(
     controller_mock: AsyncMock,


### PR DESCRIPTION
# Fix `protonvpn status` SIGABRT crash from Rust local agent threads

## Problem

`protonvpn status` crashes with `SIGABRT` and dumps a ~15 MB core when the VPN is connected. The crash originates in `local_agent.abi3.so` — the Rust native extension for ProtonVPN's local agent protocol.

### Environment

| Component | Version |
|---|---|
| OS | Linux Mint 22.3 (Zena), kernel 7.0.0-14-generic, x86_64 |
| Python | 3.12.3 |
| proton-vpn-cli | 1.0.1 |
| proton-vpn-api-core | 5.2.4 |
| proton-core | 0.7.4 |
| local_agent.abi3.so | 4.7 MB (release build, no debug symbols) |

### How to reproduce

1. Connect to any server: `protonvpn connect <server>` (WireGuard protocol).
2. Run `protonvpn status` while connected.
3. Check the exit code (`echo $?`) and look for a new core dump (`coredumpctl list | tail`).

On affected systems, `status` prints the connection details correctly but the process then aborts during interpreter shutdown (non-zero/abort exit code, new core dump entry).

### Core dump evidence

| Thread | Frame |
|---|---|
| **crashing** | `PyObject_Call` from `local_agent.abi3.so` → `PyEval_RestoreThread` detects finalization → `PyThread_exit_thread` → `abort()` |
| **main** | `Py_FinalizeEx` → `PyGC_Collect` — normal interpreter shutdown |
| **idle workers** | 15 idle tokio worker threads from the Rust runtime |

### Root cause trace

```
protonvpn status
  → status()  [server.py:239]
    → controller.get_vpn_connector()
      → VPNConnector.initialize_state()
        → _get_current_connection()
          → loads persisted connection from disk
          → Wireguard(server, creds, settings, connection_id=...)
            → _initialize_persisted_connection()
              → _async_start_local_agent_listener()
                → asyncio.run_coroutine_threadsafe(listen(), loop)
                  → Listener.connect(domain, key, cert)
                  → Listener.listen(on_status, on_error)
                    → spawns TOKIO THREADS holding Python callbacks via PyO3
```

The `status` command starts the local agent listener **solely to read the current state**. The Rust `Listener` spawns a persistent tokio runtime with background threads that hold Python callbacks. When the one-shot CLI exits:

1. `asyncio.run()` completes → Python enters `Py_FinalizeEx`
2. `_Py_IsFinalizing()` is set to true
3. A tokio thread wakes with a new status update
4. PyO3's `Python::with_gil()` calls `PyEval_RestoreThread`
5. Which checks `_Py_IsFinalizing()` → calls `PyThread_exit_thread()` → `abort()` → **SIGABRT**

## Fix

Two complementary layers:

### Layer 1: Explicit listener stop (`server.py`)

After the status output is printed, stop the `AgentListener` if it is running. This cancels the Rust `Listener.listen()` future while the asyncio loop is still alive, giving tokio time to drain its tasks before Python shutdown.

```python
if connection is not None and hasattr(connection, '_agent_listener'):
    try:
        agent_listener = connection._agent_listener
        if agent_listener.is_running:
            await asyncio.wait_for(agent_listener.stop(), timeout=5.0)
    except Exception:  # pylint: disable=broad-except
        logger.debug("Failed to stop local agent listener.", exc_info=True)
```

A 5-second `asyncio.wait_for` timeout prevents hanging if the Rust side is slow to respond. Failures are logged at debug level rather than silently swallowed, so cleanup can never crash the command but is still visible when debugging.

### Layer 2: SIGABRT safety net (`__init__.py`)

An `atexit`-registered callback installs a SIGABRT signal handler, active only during the interpreter-shutdown window. If any remaining Rust code (e.g. the `init_logger` callback stored in the native module global state) triggers a signal during `Py_FinalizeEx`, it logs a warning to stderr and converts the crash to a clean `os._exit(1)` instead of a core dump.

```python
def _handle_shutdown_abort(_signum, _frame):
    sys.stderr.write(
        "Warning: suppressed a SIGABRT during interpreter shutdown "
        "(likely from local_agent.abi3.so background threads).\n"
    )
    os._exit(1)


def _install_abort_guard():
    signal.signal(signal.SIGABRT, _handle_shutdown_abort)


atexit.register(_install_abort_guard)
```

### Why the order matters

| Phase | What happens |
|---|---|
| `status()` runs | LA listener started by `Wireguard._initialize_persisted_connection()` |
| listener `.stop()` called | Rust `Listener.listen()` future cancelled; tokio tasks dropped — threads go idle |
| `asyncio.run()` returns | Event loop closes; remaining Python tasks cancelled |
| `atexit` fires | SIGABRT handler installed for the shutdown window |
| `Py_FinalizeEx()` runs | If `init_logger` or any residual Rust code fires, SIGABRT is logged and converted to `os._exit(1)` |
| Process exits | Clean exit, no core dump |

## Tests

Added unit tests in `tests/unit/commands/test_server.py` covering the new `status` cleanup path:

- `test_status_stops_local_agent_listener_when_running`
- `test_status_does_not_stop_local_agent_listener_when_not_running`
- `test_status_succeeds_even_if_stopping_local_agent_listener_fails`

## Manual verification

```
=== 10 consecutive runs of `protonvpn status` ===
Run  1:  exit 0
Run  2:  exit 0
Run  3:  exit 0
Run  4:  exit 0
Run  5:  exit 0
Run  6:  exit 0
Run  7:  exit 0
Run  8:  exit 0
Run  9:  exit 0
Run 10:  exit 0
=== Core dumps: 0 new ===
```

## Files changed

| File | Change |
|---|---|
| `proton/vpn/cli/commands/server.py` | Explicit `AgentListener.stop()` with 5s timeout after status display |
| `proton/vpn/cli/__init__.py` | `atexit` SIGABRT guard during interpreter shutdown, logs before exiting |
| `tests/unit/commands/test_server.py` | New tests for the agent listener cleanup |

## Known limitation

`local_agent.abi3.so` stores `proton.vpn.logging.getLogger` as a global Python callback via `init_logger()`. This callback cannot be unset from Python. If Rust code emits a log during its own native module cleanup, the SIGABRT handler catches it and logs a warning. A proper fix in `proton-vpn-local-agent` — checking `Py_IsInitialized()` before dispatching Python callbacks from tokio threads — would make the signal handler unnecessary.
