### PR TITLE
fix-api-core-remove-are_free_tier_defaults

### DIFF
--- a/proton/vpn/cli/core/controller.py
+++ b/proton/vpn/cli/core/controller.py
@@ -285,7 +285,7 @@ class Controller:  # pylint: disable=too-many-public-methods
         connector = await self.get_vpn_connector()
         is_connected = connector.is_connected
         free_user_requesting_free_features =\
-            self.user_on_free_tier and settings.features.are_free_tier_defaults()
+            self.user_on_free_tier and settings.features.is_default(self._api.user_tier)
         if not free_user_requesting_free_features and is_connected:
             # paying user requesting feature changes with live connection
             # wait for LA connection event confirming feature request complete


### PR DESCRIPTION
Hi all!

Here is the patch tested in a production environment that updated the 
proton-vpn-cli API, making it compatible with the new version of proton-vpn-api-core.
Fixing the bug:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1140266

 adapt to upstream API changes in proton-vpn-api-core 5.2.5
 The Features.are_free_tier_defaults() method was removed upstream and
 replaced by Features.is_default(user_tier). This update adjusts the
 CLI accordingly and fixes incorrect API attribute access (self.api → self._api).
 
 Nilson F. SIlva