### PR TITLE
feat: allow selecting the VPN protocol from the CLI

### DIFF
--- a/proton/vpn/cli/commands/feature_setting_definitions.py
+++ b/proton/vpn/cli/commands/feature_setting_definitions.py
@@ -197,6 +197,41 @@ class NetshieldType(ClickArgType):
         return "malware-ads-trackers"
 
 
+WIREGUARD = "wireguard"
+OPENVPN_UDP = "openvpn-udp"
+OPENVPN_TCP = "openvpn-tcp"
+
+_PROTOCOL_TO_HUMAN_FRIENDLY_NAME = {
+    WIREGUARD: "WireGuard",
+    OPENVPN_UDP: "OpenVPN (UDP)",
+    OPENVPN_TCP: "OpenVPN (TCP)",
+}
+
+
+class ProtocolType(ClickArgType):
+    """Represents the VPN protocols that a user can select."""
+
+    @staticmethod
+    def get_human_friendly_state_string(value: str) -> str:
+        """Returns human friendly state string for the specified value."""
+        return _PROTOCOL_TO_HUMAN_FRIENDLY_NAME[value]
+
+    @staticmethod
+    def to_list_of_str() -> list[str]:
+        """Converts to a list of all possible click value strings"""
+        return list(_PROTOCOL_TO_HUMAN_FRIENDLY_NAME)
+
+    @staticmethod
+    def from_str(value: str) -> str:
+        """Returns value based on provided click string"""
+        return value.lower()
+
+    @staticmethod
+    def to_str(value: str) -> str:
+        """Returns click string based on provided value"""
+        return value
+
+
 @dataclass
 class ClickFeature(Feature):
     """Click specific feature data."""
@@ -458,6 +493,44 @@ Behavior:
     click_type=KillSwitchType()
 )
 
+PROTOCOL_FEATURE = ClickFeature(
+    command="protocol",
+    human_friendly_name="Protocol",
+    setting_path="protocol",
+    available_on_free_tier=True,
+    available_setting_description="Protocol used to establish the tunnel",
+    help_description="Select the protocol used to establish the VPN tunnel.",
+    value_to_help={
+        WIREGUARD: "   WireGuard over UDP (default, recommended)",
+        OPENVPN_UDP: " OpenVPN over UDP",
+        OPENVPN_TCP: " OpenVPN over TCP (works where UDP is blocked)",
+    },
+    help_epilog="""\b
+Values:
+{feature_values}
+\b
+Examples:
+  {program_name} {config_command} {set_command} {feature_command} wireguard
+  {program_name} {config_command} {set_command} {feature_command} openvpn-tcp
+\b
+Current Setting:
+  Run '{program_name} {config_command} {settings_list_command}' to see current value.
+\b
+How It Works:
+  WireGuard over UDP is the fastest option and is used by default.
+\b
+  Some networks (public hotspots, hotels, corporate WiFi) drop the UDP
+  traffic that WireGuard and OpenVPN/UDP rely on. The tunnel is created
+  but the handshake never gets a reply, so the connection times out. On
+  such a network, openvpn-tcp establishes the tunnel over TCP instead
+  and connects normally.
+\b
+Recommendation:
+  Keep wireguard unless you are on a network that blocks UDP.""",
+    click_type=ProtocolType()
+)
+
+
 BOOL_FEATURES = [
     VPN_ACCELERATOR_FEATURE,
     MODERATE_NAT_FEATURE,
@@ -467,6 +540,7 @@ BOOL_FEATURES = [
 ]
 
 ALL_FEATURES = [
+    PROTOCOL_FEATURE,
     NETSHIELD_FEATURE,
     KILLSWITCH_FEATURE,
     PORT_FORWARDING_FEATURE,

--- a/proton/vpn/cli/commands/server.py
+++ b/proton/vpn/cli/commands/server.py
@@ -36,6 +36,9 @@ from proton.vpn.cli.core.wait_for_current_tasks import wait_for_current_tasks
 from proton.vpn.session.exceptions import ServerNotFoundError
 from proton.vpn.session.servers.types import LogicalServer, ServerFeatureEnum
 from proton.vpn.cli.commands.account import SIGNIN_COMMAND
+from proton.vpn.cli.commands.feature_setting_definitions import \
+    OPENVPN_TCP, \
+    OPENVPN_UDP
 from proton.vpn.cli.commands.command_utils import \
     inform_that_expired_serverlist_will_be_updated_if_necessary
 
@@ -310,10 +313,6 @@ async def _display_relevant_server_capabilities(
                 "Connect to a P2P server to use port forwarding:"
                 f"{controller.program_name} {CONNECT_COMMAND} --p2p"
             )
-
-
-OPENVPN_UDP = "openvpn-udp"
-OPENVPN_TCP = "openvpn-tcp"
 
 
 def _display_openvpn_warning_if_necessary(protocol: str):

--- a/proton/vpn/cli/commands/settings.py
+++ b/proton/vpn/cli/commands/settings.py
@@ -36,11 +36,13 @@ from proton.vpn.cli.commands.feature_setting_definitions import \
     ToggleType, \
     KillSwitchType, \
     NetshieldType, \
+    ProtocolType, \
     CUSTOM_DNS_FEATURE, \
     IPV6_FEATURE, \
     KILLSWITCH_FEATURE, \
     NETSHIELD_FEATURE, \
-    PORT_FORWARDING_FEATURE
+    PORT_FORWARDING_FEATURE, \
+    PROTOCOL_FEATURE
 from proton.vpn.cli.commands.server import DISCONNECT_COMMAND
 
 
@@ -203,6 +205,39 @@ async def killswitch_command(ctx: click.Context, mode: str) -> None:
         _print_success_message(
             KILLSWITCH_FEATURE,
             KillSwitchType.get_human_friendly_state_string(killswitch_value)
+        )
+
+
+@set_group.command(
+    name=PROTOCOL_FEATURE.command,
+    help=PROTOCOL_FEATURE.help_description,
+    epilog=_format_setting_epilog(PROTOCOL_FEATURE)
+)
+@click.argument(
+    "protocol",
+    type=click.Choice(ProtocolType.to_list_of_str(), case_sensitive=False),
+)
+@click.pass_context
+@run_async
+async def protocol_command(ctx: click.Context, protocol: str) -> None:
+    """Select the protocol used to establish the VPN tunnel."""
+    controller = await Controller.create(params=ctx.obj, click_ctx=ctx)
+    if await controller.is_connection_active():
+        raise click.UsageError(
+            "Disconnect before changing the protocol. "
+            f"Run '{controller.program_name} {DISCONNECT_COMMAND}' first."
+        )
+
+    protocol_value = ProtocolType.from_str(protocol)
+
+    try:
+        await controller.save_feature_setting(PROTOCOL_FEATURE, protocol_value)
+    except AuthenticationRequiredError:
+        _raise_error_auth_required(controller, action="set")
+    else:
+        _print_success_message(
+            PROTOCOL_FEATURE,
+            ProtocolType.get_human_friendly_state_string(protocol_value)
         )
 
 

--- a/tests/unit/commands/test_settings.py
+++ b/tests/unit/commands/test_settings.py
@@ -29,7 +29,9 @@ from proton.vpn.cli.commands.feature_setting_definitions import \
     PORT_FORWARDING_FEATURE, \
     CUSTOM_DNS_FEATURE, \
     KILLSWITCH_FEATURE, \
+    PROTOCOL_FEATURE, \
     NetshieldType, \
+    ProtocolType, \
     CustomDNSType, \
     ClickFeature
 from proton.vpn.cli.commands.server import DISCONNECT_COMMAND
@@ -257,6 +259,62 @@ def test_modifying_killswitch_only_succeeds_when_disconnected(
     assert ("Disconnect before changing Kill Switch. "
             f"Run '{test_context.info_name} {DISCONNECT_COMMAND}' first."
             in result.output) == is_connected
+
+
+@pytest.mark.parametrize(
+    "is_connected, protocol",
+    [
+        (True, "wireguard"),
+        (True, "openvpn-tcp"),
+        (False, "wireguard"),
+        (False, "openvpn-tcp"),
+    ]
+)
+def test_modifying_protocol_only_succeeds_when_disconnected(
+    runner: CliRunner,
+    test_context: click.Context,
+    controller_mock: AsyncMock,
+    is_connected: bool,
+    protocol: str
+):
+    controller_mock.is_connection_active.return_value = is_connected
+
+    result = runner.invoke(
+        app_cmd,
+        [CONFIG_COMMAND,
+         SET_COMMAND,
+         PROTOCOL_FEATURE.command,
+         protocol],
+        parent=test_context
+    )
+
+    assert result.exit_code == (2 if is_connected else 0)
+    assert ("Disconnect before changing the protocol. "
+            f"Run '{test_context.info_name} {DISCONNECT_COMMAND}' first."
+            in result.output) == is_connected
+
+    if not is_connected:
+        controller_mock.save_feature_setting.assert_called_with(
+            PROTOCOL_FEATURE, protocol
+        )
+        assert ProtocolType.get_human_friendly_state_string(protocol) in result.output
+
+
+def test_setting_protocol_rejects_unknown_value(
+    runner: CliRunner,
+    test_context: click.Context,
+    controller_mock: AsyncMock
+):
+    controller_mock.is_connection_active.return_value = False
+
+    result = runner.invoke(
+        app_cmd,
+        [CONFIG_COMMAND, SET_COMMAND, PROTOCOL_FEATURE.command, "carrier-pigeon"],
+        parent=test_context
+    )
+
+    assert result.exit_code == 2
+    controller_mock.save_feature_setting.assert_not_called()
 
 
 def test_listing_all_settings_fails_when_not_signed_in(


### PR DESCRIPTION
Closes #26.

## What this does

Exposes the VPN protocol as a configurable setting, so it can be changed
without hand-editing `settings.json`:

```
protonvpn config set protocol wireguard
protonvpn config set protocol openvpn-udp
protonvpn config set protocol openvpn-tcp
```

It also shows up in `protonvpn config list`:

```
Current configuration
Setting                  Value
-----------------------  --------------------
protocol                 openvpn-tcp
netshield                malware-ads-trackers
kill-switch              off
...
```

## Why

On a public WiFi that drops VPN UDP traffic, `protonvpn connect` always failed with
the generic `Connection failed. Try connecting to a different server or check your
network settings.` The tunnel came up and got an address, but the WireGuard handshake
never got a reply:

```
proton0 10.2.0.2/32  TX: 148 / RX: 0
proton0 10.2.0.2/32  TX: 296 / RX: 0
```

148 bytes is exactly one WireGuard handshake initiation; two were sent and nothing came
back. TCP/443 to the same server IP worked fine, and arbitrary outbound UDP worked
(STUN on 3478/19302 responded) — the network selectively drops UDP on the ports Proton
uses. Since the local agent lives inside the tunnel, it can never answer, and the CLI
times out.

Because the protocol was not selectable, there was no way to recover from the CLI.
Switching to `openvpn-tcp` connects on that same network.

## Implementation notes

Everything needed was already in place, so this is mostly wiring:

- `create_registry()` in api-core already registers the openvpn and wireguard backends
- `VPNConnector.connect()` already takes a `protocol` argument
- `Settings.protocol` is already persisted to `settings.json`
- `_connect()` in the controller already passes `settings.protocol` through

So this adds a `ProtocolType` click arg type and a `PROTOCOL_FEATURE`, and registers the
`config set protocol` command. `get_feature_setting` / `save_feature_setting` work
unchanged via `setting_path="protocol"`.

Changing the protocol requires an inactive connection, following the same pattern the
kill switch command already uses — the setting only takes effect when the tunnel is
established, and `save_settings()` otherwise waits for a `CONNECTED` event that a
protocol change never produces.

`OPENVPN_UDP` / `OPENVPN_TCP` moved from `server.py` into `feature_setting_definitions.py`
so the new choices and the existing OpenVPN warning share one definition rather than
duplicating the strings.

### On the protun-* protocols

`protun-udp`, `protun-tcp`, `protun-tls` and `protun-smart` are deliberately **not**
offered, because they cannot currently be established at all:

```
CONN.CONNECT:START | ... / Protocol: protun-tcp / Backend: None
gi.repository.GLib.GError: nm-manager-error-quark:
    The 'protun' plugin doesn't support private connections. (4)
```

The `nm-protun.name` shipped by `python-proton-vpn-api-core` does not declare
`supports-safe-private-file-access=true`, which NetworkManager requires for the
in-memory connections this client creates (the bundled `nm-openvpn-service.name` does
declare it). Adding that key locally makes NetworkManager accept the connection and
`nm-protun-service` start, but it then stops at:

```
INFO proton_vpn_platform::protun::nm_protun_service::interfaces::network_manager]
    Secrets are needed for this connection
```

because `protun.py` uses `STORE_PRIVATE_KEY_IN_KEYRING = "1"` (`AGENT_OWNED`), so
NetworkManager asks a registered secret agent for the private key — and on a desktop
without `nm-applet`/`plasma-nm` nothing answers.

That is a separate bug and likely belongs in `python-proton-vpn-api-core`. It is worth
flagging here because `protun-tcp` / `protun-tls` are exactly the protocols that would
best solve the blocked-UDP case. They can be added to `ProtocolType` in a one-line change
once they work.

## Testing

- `pytest tests/unit` — 271 passed (6 new)
- `flake8 proton/` — clean
- `pylint` — 9.95/10; the two remaining `R0917` in `server.py` are pre-existing and
  present on `stable` unchanged
- Manually verified against a live account: `--help` output, `config list`, the
  disconnect-required guard, case-insensitive values (`OpenVPN-UDP`), and that each
  value is persisted to `settings.json`

New tests cover the disconnect-required guard (parametrised over connected/disconnected),
persistence of the chosen value, and rejection of unknown protocols. The existing
`ALL_FEATURES`-driven tests cover the new setting automatically.
